### PR TITLE
Add handling for sampling sets w/o replacement

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,9 +14,14 @@ if __name__ == '__main__':
     print("2 - Yellow")
     print("3 - Red")
     safecolor = input("Choice:")
+    print("Choose to pick sets with or without replacement")
+    print("1 - With replacement [default]")
+    print("0 - Without replacement")
+    replacement = int(input("Choice:") or 1)
     print("Ready to go!")
     msgdat = int(safecolor) - 1
     script.post({"type": "safe","id": msgdat})
+    script.post({"type": "replacement", "data": replacement})
     if(osp.exists("sets.txt")):
         txtlines = open("sets.txt").read().strip().splitlines()
         ids = list(map(int, txtlines))

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Install the hunter tourney mod by Prahaha + IDGeek through the SA2 mod manager [
 
 Provide in sets.txt (in the executable directory) a group of set IDs from a 1024 sheet of your choice, each ID separated by a new line.  You can copy+paste from the leftmost column of the 1024 sheet from this google drive folder [here](https://drive.google.com/drive/folders/1RW00L3s5yO7mS6Cf8DkzT8poYZKVW4Fl) for ease of use.
 
-Open the game with the tourney mod installed, then run the companion executable **in that order**.  Enter your preferred safe color even if you aren't doing Security Hall, and the companion will be active.
+Open the game with the tourney mod installed, then run the companion executable **in that order**.  Enter your preferred safe color even if you aren't doing Security Hall, and select whether or not you want to run with replacement (duplicates allowed) or no replacement (duplicates only after you see every set) and the companion will be active.
 
 The provided sets.txt in the release gives you a few sets with "a golden circle on a red circle" as your first piece in wild canyon, but only on first load.
 

--- a/script.js
+++ b/script.js
@@ -18,6 +18,9 @@ var safeset = false;
 var lifeptr = base.add(0x134b024);
 //upgrade
 var tscopeaddr = base.add(0x19eb31a);
+//Replacement/no replacement handling
+var replacement = true;
+var sets_to_sample = [];
 //exit game safety
 /*var entermainmenuptr = base.add(0x284486);
 var levelcount = -1;
@@ -40,8 +43,13 @@ recv("safe", function(msg){
     safe = msg.id;
 });
 
+recv("replacement", function(msg){
+    replacement = Boolean(msg.data);
+});
+
 recv("sets", function(msg){
     SETS_TO_PRACTICE = msg.sets;
+    sets_to_sample = [...SETS_TO_PRACTICE];
     console.log("Received sets");
 });
 //death restart rng
@@ -57,9 +65,19 @@ Interceptor.attach(fnsetstate, {
            console.log("Wrote new state");
        } else {
            if(SETS_TO_PRACTICE.length > 0){
-               var rand_idx = Math.floor(Math.random() * SETS_TO_PRACTICE.length);
-               nextseedptr.writeU16(SETS_TO_PRACTICE[rand_idx]);
-               console.log("Wrote " + SETS_TO_PRACTICE[rand_idx]);
+               if (replacement) {
+                    var rand_idx = Math.floor(Math.random() * SETS_TO_PRACTICE.length);
+                    nextseedptr.writeU16(SETS_TO_PRACTICE[rand_idx]);
+                    console.log("Wrote " + SETS_TO_PRACTICE[rand_idx]);
+               } else {
+                    var rand_idx = Math.floor(Math.random() * sets_to_sample.length);
+                    nextseedptr.writeU16(sets_to_sample[rand_idx]);
+                    console.log("Wrote " + sets_to_sample[rand_idx]);
+                    sets_to_sample.splice(rand_idx, 1);
+                    if (sets_to_sample.length == 0) {
+                        sets_to_sample = [...SETS_TO_PRACTICE];
+                    }
+               }
            }
        }
        //lives


### PR DESCRIPTION
Running w/o replacement means that you'll only get duplicate sets once you've encountered each set once.

My thinking is that this along with the set cover stuff I did yesterday should hopefully make it easier for new runners to learn all the pieces without getting bogged down by duplicate sets too much.